### PR TITLE
Remove robot indication from external email

### DIFF
--- a/data/mail_badge.md
+++ b/data/mail_badge.md
@@ -10,4 +10,4 @@ du {{ author.start | date: "%d/%m/%Y" }} au {{ author.end | date: "%d/%m/%Y" }} 
 {% endif %}
 
 Bonne journée,  
-Le secrétariat robotisé de l'Incubateur
+Le secrétariat de l'Incubateur

--- a/lib/betagouvbot/mail.rb
+++ b/lib/betagouvbot/mail.rb
@@ -21,7 +21,7 @@ module BetaGouvBot
 
     def format(context)
       md_source = self.class.render(@body_t, context)
-      { "personalizations": [{
+      { 'personalizations': [{
         'to': @recipients.map { |mail| { 'email' => self.class.render(mail, context) } },
         'subject': self.class.render(@subject, context)
       }],

--- a/lib/betagouvbot/mail.rb
+++ b/lib/betagouvbot/mail.rb
@@ -6,7 +6,7 @@ require 'kramdown'
 module BetaGouvBot
   class Mail
 
-    def self.from_file(body_path, recipients = [], sender = 'bot@beta.gouv.fr')
+    def self.from_file(body_path, recipients = [], sender = 'secretariat@beta.gouv.fr')
       # Email data files consist of 1 subject line plus body
       subject, *rest = File.readlines(body_path)
       Mail.new(subject.strip, rest.join, recipients, sender)


### PR DESCRIPTION
Je vois plus de risques à l'indiquer qu'à le masquer à partir du moment où l'adresse d'expédition (`secretariat@beta.gouv.fr` ?) redirige vers `contact@`.