### PR TITLE
Require internal classes only once

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,13 +1,6 @@
 require: rubocop-rspec
 
 AllCops:
-  Exclude:
-    - betagouvbot.gemspec
-    - Guardfile
-    - spec/spec_helper.rb
-    - vendor/**/*
-    - tmp/**/*
-
   TargetRubyVersion: 2.3
 
 Metrics/LineLength:
@@ -30,9 +23,6 @@ Style/FrozenStringLiteralComment:
   EnforcedStyle: always
   Enabled: true
 
-Style/EmptyLinesAroundClassBody:
-  Enabled: false
-
 Style/LambdaCall:
   Enabled: false
 
@@ -52,8 +42,7 @@ Style/BlockDelimiters:
 
 Metrics/BlockLength:
   Exclude:
-    - 'Rakefile'
-    - '**/*.rake'
+    - 'betagouvbot.gemspec'
     - 'spec/**/*.rb'
 
 RSpec/MultipleExpectations:

--- a/betagouvbot.gemspec
+++ b/betagouvbot.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/sgmap/betagouvbot'
   spec.license       = 'AGPL-3.0'
 
-  spec.files         = Dir['{lib,data}/**/*', 'README*', 'Rakefile','config.ru']
+  spec.files         = Dir['{lib,data}/**/*', 'README*', 'Rakefile', 'config.ru']
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'activesupport'

--- a/lib/betagouvbot.rb
+++ b/lib/betagouvbot.rb
@@ -1,14 +1,7 @@
 # encoding: utf-8
 # frozen_string_literal: true
 
-require 'betagouvbot/account_action'
-require 'betagouvbot/account_request'
-require 'betagouvbot/anticipator'
-require 'betagouvbot/github_actions'
-require 'betagouvbot/mailer'
-require 'betagouvbot/redirect_action'
-require 'betagouvbot/webhook'
-require 'betagouvbot/version'
+Dir[__dir__ + '/betagouvbot/**/*.rb'].each(&method(:require))
 
 module BetaGouvBot
   #

--- a/lib/betagouvbot/badge_request.rb
+++ b/lib/betagouvbot/badge_request.rb
@@ -1,10 +1,6 @@
 # encoding: utf-8
 # frozen_string_literal: true
 
-require 'betagouvbot/mail_action'
-require 'betagouvbot/mailer'
-require 'betagouvbot/mail'
-
 module BetaGouvBot
   module BadgeRequest
     module_function
@@ -29,7 +25,6 @@ module BetaGouvBot
       def client
         Mailer.client
       end
-
     end
   end
 end

--- a/lib/betagouvbot/mail.rb
+++ b/lib/betagouvbot/mail.rb
@@ -5,7 +5,6 @@ require 'kramdown'
 
 module BetaGouvBot
   class Mail
-
     attr_accessor :subject
     attr_accessor :recipients
 

--- a/lib/betagouvbot/mailer.rb
+++ b/lib/betagouvbot/mailer.rb
@@ -1,9 +1,6 @@
 # encoding: utf-8
 # frozen_string_literal: true
 
-require 'betagouvbot/mail_action'
-require 'betagouvbot/mail'
-
 module BetaGouvBot
   module Mailer
     module_function

--- a/lib/betagouvbot/mailing_list_action.rb
+++ b/lib/betagouvbot/mailing_list_action.rb
@@ -5,6 +5,7 @@ module BetaGouvBot
   class MailingListAction
     DOMAIN = 'beta.gouv.fr'
     PREFIX = "/email/domain/#{DOMAIN}"
+
     def initialize(api, listname, email)
       @api = api
       @listname = listname

--- a/lib/betagouvbot/rules.rb
+++ b/lib/betagouvbot/rules.rb
@@ -1,8 +1,6 @@
 # encoding: utf-8
 # frozen_string_literal: true
 
-require 'betagouvbot/mail'
-
 module BetaGouvBot
   RULES = {
     21 => { mail: Mail.from_file('data/mail_3w.md',

--- a/lib/betagouvbot/sorting_hat.rb
+++ b/lib/betagouvbot/sorting_hat.rb
@@ -2,10 +2,6 @@
 # frozen_string_literal: true
 
 require 'ovh/rest'
-require 'betagouvbot/mailing_list_action'
-require 'betagouvbot/mailer'
-require 'betagouvbot/mail_action'
-require 'betagouvbot/mailer'
 
 module BetaGouvBot
   module SortingHat
@@ -21,6 +17,7 @@ module BetaGouvBot
           reconcile(community, alumni, sorted[:alumni], 'alumni')
       end
 
+      # TODO: do not use exceptions for control flow
       def active?(member, date)
         Date.iso8601(member[:end]) >= date
       rescue
@@ -104,7 +101,6 @@ module BetaGouvBot
       def author(community, email)
         community.detect { |author| email == email(author) }
       end
-
     end
   end
 end

--- a/lib/betagouvbot/webhook.rb
+++ b/lib/betagouvbot/webhook.rb
@@ -2,11 +2,6 @@
 # frozen_string_literal: true
 
 require 'active_support/core_ext/hash/indifferent_access'
-require 'betagouvbot/anticipator'
-require 'betagouvbot/mailer'
-require 'betagouvbot/sorting_hat'
-require 'betagouvbot/rules'
-require 'betagouvbot/badge_request'
 require 'sinatra/base'
 require 'sendgrid-ruby'
 require 'httparty'
@@ -55,7 +50,7 @@ module BetaGouvBot
     end
 
     post '/badge' do
-      badges = BadgeRequest.(members, params['text'])
+      badges  = BadgeRequest.(members, params['text'])
       execute = params.key?('token') && (params['token'] == ENV['BADGE_TOKEN'])
       badges.map(&:execute) if execute
       { response_type: 'in_channel', text: 'OK, demande faite !' }.to_json

--- a/spec/betagouvbot/mailer_spec.rb
+++ b/spec/betagouvbot/mailer_spec.rb
@@ -1,8 +1,6 @@
 # encoding: utf-8
 # frozen_string_literal: true
 
-require 'active_support/core_ext/hash/indifferent_access'
-
 RSpec.describe BetaGouvBot::Mailer do
   Mail = BetaGouvBot::Mail
   let(:rules) { { 1 => { mail:  Mail.new('demain', nil,

--- a/spec/betagouvbot/sorting_hat_spec.rb
+++ b/spec/betagouvbot/sorting_hat_spec.rb
@@ -1,8 +1,6 @@
 # encoding: utf-8
 # frozen_string_literal: true
 
-require 'betagouvbot/mail_action'
-
 RSpec.describe BetaGouvBot::SortingHat do
   let(:yesterday)     { today - 1 }
   let(:today)         { Date.today }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ require 'rubygems'
 require 'bundler'
 Bundler.setup :default, :test
 
-Dir[File.expand_path(File.join('spec', 'support', '**', '*.rb'))].map(&method(:require))
+Dir[__dir__ + '/support/**/*.rb'].each(&method(:require))
 
 require 'betagouvbot'
 


### PR DESCRIPTION
Unlike Python or other languages, in Ruby once you require a file, its contents are available to the global scope during runtime.